### PR TITLE
dont-panic

### DIFF
--- a/rep_lang_core/Cargo.toml
+++ b/rep_lang_core/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+hdk = { version = "0.0.117", optional = true }
 holochain_serialized_bytes_derive = { version = "0.0.51", optional = true }
 quickcheck = "0.9.2"
 rand = "0.7"
 serde = { version = "1.0", optional = true }
 
 [features]
-hc = ["holochain_serialized_bytes_derive", "serde"]
+hc = ["hdk", "holochain_serialized_bytes_derive", "serde"]

--- a/rep_lang_core/src/util.rs
+++ b/rep_lang_core/src/util.rs
@@ -6,3 +6,19 @@ pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
     t.hash(&mut s);
     s.finish()
 }
+
+#[cfg(feature = "hdk")]
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => ({{
+        panic!("check Holochain error output for complete error. {:?}", hdk::prelude::error!($($arg)*))
+    }});
+}
+
+#[cfg(not(feature = "hdk"))]
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {
+        panic!($($arg)*)
+    };
+}

--- a/rep_lang_runtime/Cargo.toml
+++ b/rep_lang_runtime/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 [dependencies]
 byteorder = "1.4.3"
 combine = "4.5.2"
+hdk = { version = "0.0.117", optional = true }
 holochain_serialized_bytes_derive = { version = "0.0.51", optional = true }
 pretty = "0.10.0"
 rustyline = "6.3.0"
@@ -23,7 +24,7 @@ quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"
 
 [features]
-hc = ["holochain_serialized_bytes_derive", "serde"]
+hc = ["hdk", "holochain_serialized_bytes_derive", "serde"]
 
 [[bin]]
 name = "rli"

--- a/rep_lang_runtime/src/bin/rle.rs
+++ b/rep_lang_runtime/src/bin/rle.rs
@@ -3,6 +3,8 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 
+use rep_lang_core::error;
+
 use rep_lang_concrete_syntax::{parse::program, util::pretty::to_pretty};
 
 use rep_lang_runtime::{
@@ -19,10 +21,10 @@ fn main() -> std::io::Result<()> {
     file.read_to_string(&mut contents)?;
 
     match program().easy_parse(position::Stream::new(&contents[..])) {
-        Err(err) => panic!("parse error:\n\n{}\n", err),
+        Err(err) => error!("parse error:\n\n{}\n", err),
         Ok((prog, extra_input)) => {
             if extra_input.is_partial() {
-                panic!("error: unconsumed input: {:?}", extra_input);
+                error!("error: unconsumed input: {:?}", extra_input);
             } else {
                 // println!("{}", to_pretty(prog.ppr(), width));
                 match infer_program(Env::new(), &prog) {
@@ -45,7 +47,7 @@ fn main() -> std::io::Result<()> {
                         println!("(: {}\n   {}\n)", val_str, ty);
                         Ok(())
                     }
-                    Err(err) => panic!("type error: {:?}", err),
+                    Err(err) => error!("type error: {:?}", err),
                 }
             }
         }
@@ -56,6 +58,6 @@ fn get_fp() -> std::io::Result<String> {
     let args: Vec<String> = env::args().collect();
     match args.as_slice() {
         [_, fp] => Ok(fp.clone()),
-        _ => panic!("wanted one filepath, got {:?}", &args[1..]),
+        _ => error!("wanted one filepath, got {:?}", &args[1..]),
     }
 }

--- a/rep_lang_runtime/src/bin/rli.rs
+++ b/rep_lang_runtime/src/bin/rli.rs
@@ -2,7 +2,10 @@ use combine::{stream::position, EasyParser, StreamOnce};
 use rustyline::{error::ReadlineError, Editor};
 
 use rep_lang_concrete_syntax::{parse::defn_or_it_expr, util::pretty::to_pretty};
-use rep_lang_core::abstract_syntax::Defn;
+use rep_lang_core::{
+    abstract_syntax::Defn,
+    error,
+};
 
 use rep_lang_runtime::{
     env::*,
@@ -29,7 +32,7 @@ fn main() {
 
     let mut rl = Editor::<()>::new();
     let (width, _height) = match rl.dimensions() {
-        None => panic!("output is not a tty"),
+        None => error!("output is not a tty"),
         Some(dims) => dims,
     };
     let mut type_env = Env::new();

--- a/rep_lang_runtime/src/bin/rli.rs
+++ b/rep_lang_runtime/src/bin/rli.rs
@@ -2,10 +2,7 @@ use combine::{stream::position, EasyParser, StreamOnce};
 use rustyline::{error::ReadlineError, Editor};
 
 use rep_lang_concrete_syntax::{parse::defn_or_it_expr, util::pretty::to_pretty};
-use rep_lang_core::{
-    abstract_syntax::Defn,
-    error,
-};
+use rep_lang_core::{abstract_syntax::Defn, error};
 
 use rep_lang_runtime::{
     env::*,

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -10,7 +10,7 @@ use std::{
 use rep_lang_concrete_syntax::{sp, util::pretty::parens};
 use rep_lang_core::{
     abstract_syntax::{gas_of_expr, primop_arity, Defn, Expr, Gas, Lit, Name, PrimOp, Program},
-    app, lam, error,
+    app, error, lam,
     util::calculate_hash,
 };
 

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -10,7 +10,7 @@ use std::{
 use rep_lang_concrete_syntax::{sp, util::pretty::parens};
 use rep_lang_core::{
     abstract_syntax::{gas_of_expr, primop_arity, Defn, Expr, Gas, Lit, Name, PrimOp, Program},
-    app, lam,
+    app, lam, error,
     util::calculate_hash,
 };
 
@@ -173,7 +173,7 @@ impl<M> Default for Sto<M> {
 pub fn lookup_sto<'a, M>(es: &mut EvalState, vr: &VRef, sto: &'a mut Sto<M>) -> IValue {
     let VRef(idx) = *vr;
     match sto.sto_vec.get_mut(idx) {
-        None => panic!("lookup_sto: out of bounds"),
+        None => error!("lookup_sto: out of bounds"),
         Some(CellRedirect(vr2)) => lookup_sto(es, &vr2.clone(), sto),
         Some(CellThunk(thnk)) => match thnk {
             Ev(val) => val.clone(),
@@ -198,7 +198,7 @@ where
 {
     let VRef(idx) = *vr;
     match sto.sto_vec.get_mut(idx) {
-        None => panic!("lookup_sto: out of bounds"),
+        None => error!("lookup_sto: out of bounds"),
         Some(CellRedirect(vr2)) => get_sto(es, &vr2.clone(), sto),
         Some(CellThunk(thnk)) => thnk.clone(),
     }
@@ -463,7 +463,7 @@ macro_rules! primop_binop_int {
                 let val = VInt(a_ $op b_);
                 add_to_sto(Ev(val), $sto)
             }
-            _ => panic!("{}: bad types", $op_name),
+            _ => error!("{}: bad types", $op_name),
         }
     };
 }
@@ -490,7 +490,7 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                         let val = VBool(a_ == b_);
                         add_to_sto(Ev(val), sto)
                     }
-                    _ => panic!("==: bad types"),
+                    _ => error!("==: bad types"),
                 },
                 PrimOp::And => match (
                     lookup_sto(es, &args_v[0], sto),
@@ -500,7 +500,7 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                         let val = VBool(a_ && b_);
                         add_to_sto(Ev(val), sto)
                     }
-                    _ => panic!("and: bad types"),
+                    _ => error!("and: bad types"),
                 },
                 PrimOp::Or => match (
                     lookup_sto(es, &args_v[0], sto),
@@ -510,14 +510,14 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                         let val = VBool(a_ || b_);
                         add_to_sto(Ev(val), sto)
                     }
-                    _ => panic!("or: bad types"),
+                    _ => error!("or: bad types"),
                 },
                 PrimOp::Not => match lookup_sto(es, &args_v[0], sto) {
                     VBool(a_) => {
                         let val = VBool(!a_);
                         add_to_sto(Ev(val), sto)
                     }
-                    _ => panic!("not: bad types"),
+                    _ => error!("not: bad types"),
                 },
                 PrimOp::Lt => match (
                     lookup_sto(es, &args_v[0], sto),
@@ -527,7 +527,7 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                         let val = VBool(a_ < b_);
                         add_to_sto(Ev(val), sto)
                     }
-                    _ => panic!("<: bad types"),
+                    _ => error!("<: bad types"),
                 },
                 PrimOp::Gt => match (
                     lookup_sto(es, &args_v[0], sto),
@@ -537,13 +537,13 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                         let val = VBool(a_ > b_);
                         add_to_sto(Ev(val), sto)
                     }
-                    _ => panic!(">: bad types"),
+                    _ => error!(">: bad types"),
                 },
                 PrimOp::Null => {
                     let val = match lookup_sto(es, &args_v[0], sto) {
                         VCons(_, _) => VBool(false),
                         VNil => VBool(true),
-                        _ => panic!("null: bad types"),
+                        _ => error!("null: bad types"),
                     };
                     add_to_sto(Ev(val), sto)
                 }
@@ -553,11 +553,11 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                 }
                 PrimOp::Fst => match lookup_sto(es, &args_v[0], sto) {
                     VPair(a, _) => a,
-                    _ => panic!("fst: bad types"),
+                    _ => error!("fst: bad types"),
                 },
                 PrimOp::Snd => match lookup_sto(es, &args_v[0], sto) {
                     VPair(_, b) => b,
-                    _ => panic!("snd: bad types"),
+                    _ => error!("snd: bad types"),
                 },
                 PrimOp::Cons => {
                     let val = VCons(args_v[0], args_v[1]);
@@ -565,15 +565,15 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                 }
                 PrimOp::Head => match lookup_sto(es, &args_v[0], sto) {
                     VCons(hd, _tl) => hd,
-                    VNil => panic!("head: called on empty list"),
-                    _ => panic!("head: bad types"),
+                    VNil => error!("head: called on empty list"),
+                    _ => error!("head: bad types"),
                 },
                 PrimOp::Tail => match lookup_sto(es, &args_v[0], sto) {
                     VCons(_hd, tl) => tl,
-                    VNil => panic!("tail: called on empty list"),
-                    _ => panic!("tail: bad types"),
+                    VNil => error!("tail: called on empty list"),
+                    _ => error!("tail: bad types"),
                 },
-                PrimOp::Nil => panic!("nil: application of non-function"),
+                PrimOp::Nil => error!("nil: application of non-function"),
             }
         }
 
@@ -585,7 +585,7 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
             Expr::Lit(Lit::LBool(x)) => add_to_sto(Ev(VBool(*x)), sto),
 
             Expr::Var(x) => match env.get(x) {
-                None => panic!("impossible: free variable: {:?}", x),
+                None => error!("impossible: free variable: {:?}", x),
                 Some(v) => *v,
             },
 
@@ -603,7 +603,7 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                 match lookup_sto(es, &tst_ref, sto) {
                     VBool(true) => eval_(env, sto, es, thn),
                     VBool(false) => eval_(env, sto, es, els),
-                    _ => panic!("impossible: non-bool in test position of if"),
+                    _ => error!("impossible: non-bool in test position of if"),
                 }
             }
 
@@ -651,7 +651,7 @@ pub fn eval_<M>(env: &ITermEnv, sto: &mut Sto<M>, es: &mut EvalState, expr: &Exp
                         new_env.insert(nm, arg_thnk_ref);
                         eval_(&new_env, sto, es, &bd)
                     }
-                    _ => panic!("impossible: non-closure in function position of app"),
+                    _ => error!("impossible: non-closure in function position of app"),
                 }
             }
 
@@ -696,7 +696,7 @@ fn primop_apply_case(es: &mut EvalState, expr: &Expr) -> PrimOpApplyCase {
         Some((op, args)) => {
             let delta = primop_arity(&op) - args.len();
             match delta.cmp(&0) {
-                Ordering::Less => panic!(
+                Ordering::Less => error!(
                     "primop_apply_case: impossible: primop {:?} is over-applied",
                     op
                 ),
@@ -828,7 +828,7 @@ impl Normalizable for Expr {
             Lit(_) | Prim(_) => self.clone(),
 
             Var(x) => match hm.get(x) {
-                None => panic!("normalize: free variable: {:?}", x),
+                None => error!("normalize: free variable: {:?}", x),
                 Some(v) => Var(v.clone()),
             },
 

--- a/rep_lang_runtime/src/infer.rs
+++ b/rep_lang_runtime/src/infer.rs
@@ -1,10 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::iter;
 
-use rep_lang_core::{
-    abstract_syntax::*,
-    error,
-};
+use rep_lang_core::{abstract_syntax::*, error};
 
 use super::{env::*, types::*};
 

--- a/rep_lang_runtime/src/infer.rs
+++ b/rep_lang_runtime/src/infer.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::iter;
 
-use rep_lang_core::abstract_syntax::*;
+use rep_lang_core::{
+    abstract_syntax::*,
+    error,
+};
 
 use super::{env::*, types::*};
 
@@ -328,7 +331,7 @@ fn norm_type(hm: &HashMap<Tv, Tv>, ty: Type) -> Type {
         Type::TCon(a) => Type::TCon(a),
         Type::TVar(a) => match hm.get(&a) {
             Some(x) => Type::TVar(x.clone()),
-            None => panic!("norm_type: impossible: type var not in signature"),
+            None => error!("norm_type: impossible: type var not in signature"),
         },
         Type::TList(a) => {
             let a_ = norm_type(hm, *a);
@@ -397,7 +400,7 @@ pub fn unify_many(mut ts_1: Vec<Type>, mut ts_2: Vec<Type>) -> Result<Subst, Typ
                 let subst_2 = unify_many(ts_1, ts_2)?;
                 Ok(compose(subst_2, subst_1))
             }
-            _ => panic!("unify_many: impossible: case handled above"),
+            _ => error!("unify_many: impossible: case handled above"),
         }
     }
 }

--- a/rep_lang_runtime/src/test/eval.rs
+++ b/rep_lang_runtime/src/test/eval.rs
@@ -55,8 +55,8 @@ pub mod eval_unit {
         infer::*,
         vcons,
     };
-    use rep_lang_core::error;
     use rep_lang_concrete_syntax::parse::expr;
+    use rep_lang_core::error;
 
     fn ifv<M: Clone>(v: Value<VRef, VRef>) -> FlatValue<M> {
         value_to_flat_value(&mut EvalState::new(), &v, &mut Sto::<M>::new())

--- a/rep_lang_runtime/src/test/eval.rs
+++ b/rep_lang_runtime/src/test/eval.rs
@@ -2,10 +2,10 @@
 macro_rules! check_eval_expr {
     ( $str: expr, $expected_val: expr ) => {
         match expr().easy_parse(position::Stream::new(&$str[..])) {
-            Err(err) => panic!("parse error:\n\n{}\n", err),
+            Err(err) => error!("parse error:\n\n{}\n", err),
             Ok((expr, extra_input)) => {
                 if extra_input.is_partial() {
-                    panic!("error: unconsumed input: {:?}", extra_input);
+                    error!("error: unconsumed input: {:?}", extra_input);
                 } else {
                     match infer_expr(&Env::new(), &expr) {
                         Ok(_sc) => {
@@ -21,7 +21,7 @@ macro_rules! check_eval_expr {
                                 "interpreted value differs from give expected value"
                             )
                         }
-                        Err(err) => panic!("type error: {:?}", err),
+                        Err(err) => error!("type error: {:?}", err),
                     }
                 }
             }
@@ -55,6 +55,7 @@ pub mod eval_unit {
         infer::*,
         vcons,
     };
+    use rep_lang_core::error;
     use rep_lang_concrete_syntax::parse::expr;
 
     fn ifv<M: Clone>(v: Value<VRef, VRef>) -> FlatValue<M> {


### PR DESCRIPTION
switch `panic`s to Holochain-conscious `error` macro

Holochain doesn't seem to handle `panic` well - the message is lost and
the backtrace is wasm-garbled. `hdk` provides `error` which actually
gets rendered properly. however it does not have the same polymorphic
type as `panic`. therefore I introduce `rep_lang_core::util::error`
which calls `hdk`s `error` inside of `panic`, to get the best of both
worlds. it seems to work decently well. the macro is conditional
depending on `hdk` as an optional dependencies, which means that on
non-Holochain platforms a regular `panic` will be used.