### PR TITLE
nixify ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15
-    - run: nix flake check
+    - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose"
+    - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose"
+    - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose"
 
 #   test:
 #     name: test with Rust ${{ matrix.rust }} on ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,4 @@
-# lifted from https://shift.click/blog/github-actions-rust/#basic-rust-starter-template
-# thanks 🙏
-name: CI
-
+name: "CI"
 on:
   pull_request:
   push:
@@ -12,49 +9,41 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  test:
-    name: test with Rust ${{ matrix.rust }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { rust: stable,           os: ubuntu-latest }
-          # - { rust: beta,             os: ubuntu-latest }
-          # - { rust: nightly,          os: ubuntu-latest }
-    steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: ${{ matrix.rust }}
-      - run: cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose
-      - run: cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose
-      - run: cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose
-      # - run: cargo test --verbose --workspace --all-features
-      # - run: cargo test --verbose --workspace --no-default-features
 
-  # clippy:
-  #   name: Lint with clippy
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     RUSTFLAGS: -Dwarnings
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: hecrj/setup-rust-action@v1
-  #       with:
-  #         components: clippy
-  #     - run: cargo clippy --workspace --all-targets --verbose
-  #     - run: cargo clippy --workspace --all-targets --verbose --no-default-features
-  #     - run: cargo clippy --workspace --all-targets --verbose --all-features
-
-  rustfmt:
-    name: cargo fmt
+  tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
-        with:
-          components: rustfmt
-      - run: cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo fmt -- --check
-      - run: cd rep_lang_core && CARGO_TARGET_DIR=../target cargo fmt -- --check
-      - run: cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo fmt -- --check
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+    - run: nix flake check
+
+#   test:
+#     name: test with Rust ${{ matrix.rust }} on ${{ matrix.os }}
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - { rust: stable,           os: ubuntu-latest }
+#           # - { rust: beta,             os: ubuntu-latest }
+#           # - { rust: nightly,          os: ubuntu-latest }
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: hecrj/setup-rust-action@v1
+#         with:
+#           rust-version: ${{ matrix.rust }}
+#       - run: cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose
+#       - run: cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose
+#       - run: cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose
+#
+#   rustfmt:
+#     name: cargo fmt
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: hecrj/setup-rust-action@v1
+#         with:
+#           components: rustfmt
+#       - run: cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo fmt -- --check
+#       - run: cd rep_lang_core && CARGO_TARGET_DIR=../target cargo fmt -- --check
+#       - run: cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo fmt -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: cachix/install-nix-action@v15
       with:
         extra_nix_config: |
-          trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=
+          trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.holo.host https://holochain-ci.cachix.org https://cache.nixos.org/
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=
+          substituters = https://cache.holo.host https://holochain-ci.cachix.org https://cache.nixos.org/
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
         extra_nix_config: |
           trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.holo.host https://holochain-ci.cachix.org https://cache.nixos.org/
+    - uses: cachix/cachix-action@v10
+      with:
+        name: neighbourhoods
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose"
@@ -32,6 +36,10 @@ jobs:
         extra_nix_config: |
           trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.holo.host https://holochain-ci.cachix.org https://cache.nixos.org/
+    - uses: cachix/cachix-action@v10
+      with:
+        name: neighbourhoods
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo fmt -- --check"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo fmt -- --check"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo fmt -- --check"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
 
-  tests:
+  cargo_tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
@@ -23,33 +23,15 @@ jobs:
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose"
 
-#   test:
-#     name: test with Rust ${{ matrix.rust }} on ${{ matrix.os }}
-#     runs-on: ${{ matrix.os }}
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         include:
-#           - { rust: stable,           os: ubuntu-latest }
-#           # - { rust: beta,             os: ubuntu-latest }
-#           # - { rust: nightly,          os: ubuntu-latest }
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: hecrj/setup-rust-action@v1
-#         with:
-#           rust-version: ${{ matrix.rust }}
-#       - run: cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose
-#       - run: cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose
-#       - run: cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose
-#
-#   rustfmt:
-#     name: cargo fmt
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: hecrj/setup-rust-action@v1
-#         with:
-#           components: rustfmt
-#       - run: cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo fmt -- --check
-#       - run: cd rep_lang_core && CARGO_TARGET_DIR=../target cargo fmt -- --check
-#       - run: cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo fmt -- --check
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://cache.holo.host https://holochain-ci.cachix.org https://cache.nixos.org/
+    - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo fmt -- --check"
+    - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo fmt -- --check"
+    - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo fmt -- --check"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         name: neighbourhoods
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: Swatinem/rust-cache@v1
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose"
@@ -40,6 +41,7 @@ jobs:
       with:
         name: neighbourhoods
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - uses: Swatinem/rust-cache@v1
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo fmt -- --check"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo fmt -- --check"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo fmt -- --check"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,14 @@ jobs:
         extra_nix_config: |
           trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.holo.host https://holochain-ci.cachix.org https://cache.nixos.org/
+    - name: ⚡ Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: cachix/cachix-action@v10
       with:
         name: neighbourhoods
@@ -36,6 +44,14 @@ jobs:
         extra_nix_config: |
           trusted-public-keys = cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ= holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.holo.host https://holochain-ci.cachix.org https://cache.nixos.org/
+    - name: ⚡ Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: cachix/cachix-action@v10
       with:
         name: neighbourhoods

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
       with:
         name: neighbourhoods
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - uses: Swatinem/rust-cache@v1
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo test --verbose"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo test --verbose"
@@ -41,7 +40,6 @@ jobs:
       with:
         name: neighbourhoods
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - uses: Swatinem/rust-cache@v1
     - run: nix-shell --command "cd rep_lang_concrete_syntax && CARGO_TARGET_DIR=../target cargo fmt -- --check"
     - run: nix-shell --command "cd rep_lang_core && CARGO_TARGET_DIR=../target cargo fmt -- --check"
     - run: nix-shell --command "cd rep_lang_runtime && CARGO_TARGET_DIR=../target cargo fmt -- --check"

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1652544855,
-        "narHash": "sha256-b7ToXDqgTXsAWPluHEiFmiqaJwIrdSyJgyAOBfty5xo=",
+        "lastModified": 1653986861,
+        "narHash": "sha256-LG+0bIyNI5V5mcNPOCjoQrdiu1S1PIBAaQqXetbTLik=",
         "owner": "cargo2nix",
         "repo": "cargo2nix",
-        "rev": "2cf825c2bd570e8561132f62cb9522258a4b4956",
+        "rev": "f1059d071a1f12d379f5628c30d45c238c83572a",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -85,21 +85,6 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1652733177,
-        "narHash": "sha256-mRpdBbVk8tbYVgEE6oTBbFT1vkVdF7EzaP7bMQ26wWA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04b4d989fda8f14e6fcd1fee631eab9c54d15b97",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "locked": {
         "lastModified": 1637014545,
         "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
@@ -113,16 +98,32 @@
         "type": "github"
       }
     },
+    "holonix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653981208,
+        "narHash": "sha256-BXhJWaBR6B1Ino52PLwVqucq+DJnUajiGY7XrGl2aOw=",
+        "owner": "holochain",
+        "repo": "holonix",
+        "rev": "569f0463c99d488db9016cec11834f6dd9d3f159",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "repo": "holonix",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1652722411,
-        "narHash": "sha256-FxzNgYiH9c91hUVAntcjrqY//KOTUPP2a4e8Wyuysxg=",
+        "lastModified": 1653413650,
+        "narHash": "sha256-wojDHjb+eU80MPH+3HQaK0liUy8EgR95rvmCl24i58Y=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "94beb7a3edfeb3bcda65fa3f2ebc48ec6b40bf72",
+        "rev": "69daaceebe12c070cd5ae69ba38f277bbf033695",
         "type": "github"
       },
       "original": {
@@ -131,29 +132,53 @@
         "type": "github"
       }
     },
+    "nh-nix-env": {
+      "inputs": {
+        "cargo2nix": "cargo2nix",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "holonix": "holonix",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1654035468,
+        "narHash": "sha256-l9fsc2CHIQw3FTCKL6EcjxcMyFx+8gK3iNNgsH6Evzs=",
+        "owner": "neighbour-hoods",
+        "repo": "nh-nix-env",
+        "rev": "0e758ada092d3c6576b3987a560a5d6c610e7932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neighbour-hoods",
+        "repo": "nh-nix-env",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652298859,
-        "narHash": "sha256-hcwRboK+NxMWUJh0fQ3VsocDcAHrYJ95FmPEHlddV0Y=",
+        "lastModified": 1653896915,
+        "narHash": "sha256-BWrtLy5LLlVgfoqyLKSviayyDtidefKX+UAGPakN2Pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "051448e41537c3463ae776d46115d01afb6c498d",
+        "rev": "be5e3632be60356fabde8a25718018a50bb62d6f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-21.11",
+        "ref": "release-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1652692103,
-        "narHash": "sha256-ygRLh8g0F/WkVCSfQcxMoVaaD45i6Ky+f+b4wCOazag=",
+        "lastModified": 1653918805,
+        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "556ce9a40abde33738e6c9eac65f965a8be3b623",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
         "type": "github"
       },
       "original": {
@@ -163,11 +188,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1652659998,
-        "narHash": "sha256-FqNrXC1EE6U2RACwXBlsAvg1lqQGLYpuYb6+W3DL9vA=",
+        "lastModified": 1653931853,
+        "narHash": "sha256-O3wncIouj9x7gBPntzHeK/Hkmm9M1SGlYq7JI7saTAE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1d7db1b9e4cf1ee075a9f52e5c36f7b9f4207502",
+        "rev": "f1c167688a6f81f4a51ab542e5f476c8c595e457",
         "type": "github"
       },
       "original": {
@@ -195,28 +220,28 @@
     },
     "root": {
       "inputs": {
-        "cargo2nix": "cargo2nix",
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_3",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_3",
-        "rust-overlay": "rust-overlay_2"
+        "nh-nix-env": "nh-nix-env"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "nh-nix-env",
+          "cargo2nix",
+          "flake-utils"
+        ],
         "nixpkgs": [
+          "nh-nix-env",
           "cargo2nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1652323265,
-        "narHash": "sha256-pomEMZodDULsRJUuNermSxd3tU7hOySjUsgoz9PNxjI=",
+        "lastModified": 1653878966,
+        "narHash": "sha256-T51Gck/vrJZi1m+uTbhEFTRgZmE59sydVONadADv358=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "901ae1942bc49539c246e8e430c2181129a5a627",
+        "rev": "8526d618af012a923ca116be9603e818b502a8db",
         "type": "github"
       },
       "original": {
@@ -227,15 +252,15 @@
     },
     "rust-overlay_2": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1652755477,
-        "narHash": "sha256-igHFY7xjIJG6R9tgz8ilxOi50nF/lo3d9jJEGTX3XIk=",
+        "lastModified": 1653965133,
+        "narHash": "sha256-N3sguyZc55GvT6gNXxZpZDrpKwC7QvErnbKxaKdOvKY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7a9b1da03a2aa9d95fdc577772982e4c70b5e750",
+        "rev": "299e85fc8fd9def5fdb9d517c9f367f8d15bd0de",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -143,11 +143,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1654035468,
-        "narHash": "sha256-l9fsc2CHIQw3FTCKL6EcjxcMyFx+8gK3iNNgsH6Evzs=",
+        "lastModified": 1654036802,
+        "narHash": "sha256-cvaqydObwpqamxgInS86U1i+7OoTBXTlHC6aKeEitYs=",
         "owner": "neighbour-hoods",
         "repo": "nh-nix-env",
-        "rev": "0e758ada092d3c6576b3987a560a5d6c610e7932",
+        "rev": "80dd82f5b4a1896e70a8bc5454aefd54d18a943e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,37 +12,37 @@
     in
     flake-utils.lib.eachSystem nh-supported-systems (system:
       let
-        pkgs = nh-nix-env.values.pkgs;
+        pkgs = nh-nix-env.values.${system}.pkgs;
       in
       {
-        devShell = nh-nix-env.shells.${system}.rustDevShell {};
+        devShells.default = nh-nix-env.shells.${system}.rustDevShell {};
 
         # warning: this is broken due to
         # https://github.com/nix-community/naersk/issues/133
-        packages.rep_lang_runtime =
-          let
-            rust = pkgs.rust-bin.stable.${rustVersion}.default;
-
-            naersk' = pkgs.callPackage naersk {
-              cargo = rust;
-              rustc = rust;
-            };
-          in
-          naersk'.buildPackage {
-            src = ./rep_lang_runtime;
-            copyLibs = true;
-          };
+        # packages.rep_lang_runtime =
+        #   let
+        #     rust = pkgs.rust-bin.stable.${rustVersion}.default;
+        #
+        #     naersk' = pkgs.callPackage naersk {
+        #       cargo = rust;
+        #       rustc = rust;
+        #     };
+        #   in
+        #   naersk'.buildPackage {
+        #     src = ./rep_lang_runtime;
+        #     copyLibs = true;
+        #   };
 
         # warning: this is broken due to
         # https://github.com/cargo2nix/cargo2nix/issues/211
-        packages.rep_lang_runtime-cargo2nix =
-          let
-            rustPkgs = pkgs.rustBuilder.makePackageSet' {
-              rustChannel = rustVersion;
-              packageFun = import ./rep_lang_runtime/Cargo.nix;
-            };
-          in
-          rustPkgs.workspace.rep_lang_runtime {};
+        # packages.rep_lang_runtime-cargo2nix =
+        #   let
+        #     rustPkgs = pkgs.rustBuilder.makePackageSet {
+        #       rustChannel = rustVersion;
+        #       packageFun = import ./rep_lang_runtime/Cargo.nix;
+        #     };
+        #   in
+        #   rustPkgs.workspace.rep_lang_runtime {};
 
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,41 +1,22 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay.url = "github:oxalica/rust-overlay";
-    cargo2nix.url = "github:cargo2nix/cargo2nix";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-    naersk.url = "github:nix-community/naersk";
+    nh-nix-env.url = "github:neighbour-hoods/nh-nix-env";
   };
 
-  outputs = { nixpkgs, flake-utils, rust-overlay, cargo2nix, naersk, ... }:
-    flake-utils.lib.eachSystem ["x86_64-linux" "aarch64-linux"] (system:
+  outputs = { nh-nix-env, ... }:
+    let
+      flake-utils = nh-nix-env.metavalues.flake-utils;
+      nh-supported-systems = nh-nix-env.metavalues.nh-supported-systems;
+      rustVersion = nh-nix-env.metavalues.rustVersion;
+      naersk = nh-nix-env.metavalues.naersk;
+    in
+    flake-utils.lib.eachSystem nh-supported-systems (system:
       let
-
-        overlays = [
-          (import rust-overlay)
-          cargo2nix.overlay
-        ];
-
-        pkgs = import nixpkgs {
-          inherit system overlays;
-        };
-
-        rustVersion = "1.59.0";
-
+        pkgs = nh-nix-env.values.pkgs;
       in
-
       {
 
-        devShell = pkgs.mkShell {
-          buildInputs = [
-            pkgs.rust-bin.stable.${rustVersion}.default
-            cargo2nix.defaultPackage.${system}
-          ];
-        };
+        devShell = nh-nix-env.packages.${system}.rustDevShell;
 
         # warning: this is broken due to
         # https://github.com/nix-community/naersk/issues/133

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         pkgs = nh-nix-env.values.${system}.pkgs;
       in
       {
-        devShells.default = nh-nix-env.shells.${system}.rustDevShell {};
+        devShell = nh-nix-env.shells.${system}.rustDevShell {};
 
         # warning: this is broken due to
         # https://github.com/nix-community/naersk/issues/133

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,7 @@
         pkgs = nh-nix-env.values.pkgs;
       in
       {
-
-        devShell = nh-nix-env.packages.${system}.rustDevShell;
+        devShell = nh-nix-env.shells.${system}.rustDevShell {};
 
         # warning: this is broken due to
         # https://github.com/nix-community/naersk/issues/133

--- a/rep_lang_core/Cargo.toml
+++ b/rep_lang_core/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "../LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hdk = { version = "0.0.131", optional = true }
+hdk = { version = "0.0.132", optional = true }
 holochain_serialized_bytes_derive = { version = "0.0.51", optional = true }
 quickcheck = "0.9.2"
 rand = "0.7"

--- a/rep_lang_runtime/Cargo.lock
+++ b/rep_lang_runtime/Cargo.lock
@@ -190,9 +190,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.131"
+version = "0.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb99aecb9caac2bbff93ffcd8b612c482f243bd0691673d9fabc88db7241b870"
+checksum = "c810d82d2e03e9cc6bef97c5f5612a2f0b6b0536959a8f42acb66b5d788d351e"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.32"
+version = "0.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7038542775e193c78e229159b17fa792e604d5f5f547635b88d9b4222303b1"
+checksum = "b1aee6278daf1838c0572d2c24c33a2b117836f04aea0afacacf74beaa8b3ea4"
 dependencies = [
  "holochain_integrity_types",
  "paste",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.0.24"
+version = "0.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41531bb2e95b67a13d10e14f7f198e6bd394b4d9b861ca44c9135b6e1e52a9a6"
+checksum = "7a1b1c36e62a6d54082c2a049c93786663385d7825cd732731417525e53f4728"
 dependencies = [
  "holochain_serialized_bytes",
  "kitsune_p2p_dht_arc",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_deterministic_integrity"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18152fd1997312d668f0b2a88ce5691a12ab175ff2a4fd86e721310c18695ce"
+checksum = "214a07c6c8292a004f6009e6361504fef0d4ffc10467fcde3a9242559a2af4f9"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876860141af2bbb9477b737a2cf6afe2669bd9cb0724c2d889c0a7d7ee7b9997"
+checksum = "d6aa5a3f796a046e91aca097cb426442e60f0af3e2ed84a434c8d58c73cbd704"
 dependencies = [
  "holo_hash",
  "holochain_serialized_bytes",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.32"
+version = "0.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb9f5d7fcd5bd499aeb38bd99cb7ffecb2d57ced10c8a245c8b8104c93821ca"
+checksum = "2aef979eec3256a1b50aa88ea41507b389378b17fbc3bdec251af0b1025540ab"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",

--- a/rep_lang_runtime/Cargo.toml
+++ b/rep_lang_runtime/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../LICENSE"
 [dependencies]
 byteorder = "1.4.3"
 combine = "4.5.2"
-hdk = { version = "0.0.131", optional = true }
+hdk = { version = "0.0.132", optional = true }
 holochain_serialized_bytes_derive = { version = "0.0.51", optional = true }
 pretty = "0.10.0"
 rustyline = "6.3.0"


### PR DESCRIPTION
use https://github.com/cachix/install-nix-action to provision the dev environment (rather than `hecrj/setup-rust-action@v1`), so that we are dev-ing and CI-test-ing with the same (nix guaranteed) environment.

closes #37.

todo:

- [x] use https://github.com/cachix/cachix-action to cache nix derivations
- [ ] look at https://github.com/Swatinem/rust-cache or other Rust caching to speed rust builds